### PR TITLE
Add missing syntax highlighting based on grammar.py

### DIFF
--- a/syntaxes/sdoc.tmLanguage.json
+++ b/syntaxes/sdoc.tmLanguage.json
@@ -20,6 +20,9 @@
 			"include": "#requirement"
 		},
 		{
+			"include": "#composite_requirement"
+		},
+		{
 			"include": "#freetext"
 		},
 		{
@@ -84,7 +87,22 @@
 		"document_field_name": {
 			"patterns": [{
 				"name": "keyword.control.sdoc",
-				"match": "^\\b(TITLE|UID|VERSION|CLASSIFICATION)\\b:"
+				"match": "^\\b(MID|TITLE|UID|VERSION|CLASSIFICATION|REQ_PREFIX)\\b:"
+			}]
+		},
+		"document_root": {
+			"patterns": [{
+				"name": "constant.numeric.sdoc",
+				"begin": "(^ROOT:)",
+				"end": "$",
+				"beginCaptures": {
+					"0": { "name": "keyword.control.sdoc" }
+				},
+				"patterns": [
+					{
+						"include": "#choice_boolean"
+					}
+				]
 			}]
 		},
 		"document_options": {
@@ -97,6 +115,9 @@
 				},
 				"patterns": [
 					{
+						"include": "#document_options_mid"
+					},
+					{
 						"include": "#document_options_markup"
 					},
 					{
@@ -107,6 +128,21 @@
 					},
 					{
 						"include": "#document_options_requirement_in_toc"
+					}
+				]
+			}]
+		},
+		"document_options_mid": {
+			"patterns": [{
+				"name": "constant.numeric.sdoc",
+				"begin": "(^\\s\\sENABLE_MID:)",
+				"end": "$",
+				"beginCaptures": {
+					"0": { "name": "keyword.control.sdoc" }
+				},
+				"patterns": [
+					{
+						"include": "#choice_boolean"
 					}
 				]
 			}]
@@ -174,6 +210,9 @@
 						"include": "#document_field_name"
 					},
 					{
+						"include": "#document_root"
+					},
+					{
 						"include": "#document_options"
 					}
 				]
@@ -217,6 +256,10 @@
 				{
 					"name": "keyword.sdoc",
 					"match": "^\\[\\/?SECTION\\]$"
+				},
+				{
+					"name": "keyword.sdoc",
+					"match": "^\\[\\/?COMPOSITE_REQUIREMENT\\]$"
 				}
 			]
 		},
@@ -226,7 +269,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.sdoc",
-					"match": "^(UID|TITLE):\\s"
+					"match": "^(MID|UID|LEVEL|TITLE|REQ_PREFIX):\\s"
 				}
 			],
 			"captures": {
@@ -237,7 +280,7 @@
 		},
 		"requirement_fields": {
 			"patterns": [{
-				"match": "^(UID|REFS|TITLE|STATEMENT|RATIONALE|COMMENT):\\s",
+				"match": "^(MID|UID|LEVEL|STATUS|TAGS|TITLE|STATEMENT|RATIONALE|COMMENT|RELATIONS):\\s",
 				"name": "keyword.control.sdoc"
 			}]
 		},
@@ -249,6 +292,26 @@
 		},
 		"requirement": {
 			"begin": "^\\[REQUIREMENT\\]$",
+			"end": "^$",
+			"patterns": [
+				{
+					"include": "#field_rst_value"
+				},
+				{
+					"include": "#requirement_fields"
+				},
+				{
+					"include": "#requirement_field_params"
+				}
+			],
+			"captures": {
+				"0": {
+					"name": "keyword.sdoc"
+				}
+			}
+		},
+		"composite_requirement": {
+			"begin": "^\\[COMPOSITE_REQUIREMENT\\]$",
 			"end": "^$",
 			"patterns": [
 				{


### PR DESCRIPTION
Hi,

I've dabbled in VS Codium language highlighting. And I noticed that there were some keywords that weren't highlighting properly for SDoc files. So I figured I'd take a look and try to fix that if I can.

I looked at https://github.com/strictdoc-project/strictdoc/blob/590aaf1c4342d381329b2f965e7659acd6b451e8/strictdoc/backend/sdoc/grammar/grammar.py and added everything I could interpret as grammar. I might have made mistakes, but I should be at least 90% there.

When I came to add this PR, imagine my surprise to find issue #7! So I hope this helps out. I have added `MID`, `STATUS`, and `RELATIONS`... as well as `REQ_PREFIX`, `ENABLE_MID`, `ROOT`, and `[COMPOSITE_REQUIREMENT]`.

Obviously I might not have fit your exact style or method, so please edit those as you see fit.

And I didn't notice any tests, automated or manual. But I did open every single SDoc file in https://github.com/strictdoc-project/strictdoc-examples/ for manual review of syntax highlighting. I don't know enough to evaluate the syntax highlighting for embedded RST. But the only thing that didn't highlight properly was the `REFS`, which I intentionally removed highlighting for. You may want to re-add that (or color it differently during a transition period) as you shift from `REFS` to `RELATIONS`.

Thanks again for a great tool and helpers like this repo to use it!