### PR TITLE
Better copy/install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ git clone git@github.com:strictdoc-project/strictdoc.tmLanguage.git
 Copy the cloned folder as-is to your user's VS Code extensions folder:
 
 ```bash
-cp -rv strictdoc.tmLanguage $HOME/.vscode/extensions/
+cp -rv strictdoc.tmLanguage/* $HOME/.vscode/extensions/
 ```
 
 This instruction has been tested to work correctly and is taken from:


### PR DESCRIPTION
Change cp to exclude dotfiles from the copy/install

Hi, me again. :smile: 

I went to install the updated extension and noticed that `.git/` and other dotfiles were being copied to the extension directory.

I assume that dotfiles and dotdirs like `.gitattributes` and `.vscode/` are not needed for the proper operation of the extension. So I'm proposing a simple doc change that will exclude them naturally.