### PR TITLE
feat(sdoc.tmLanguage.json): change content type: "source.sdoc" -> "text.strictdoc"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grammars": [
       {
         "language": "sdoc",
-        "scopeName": "source.sdoc",
+        "scopeName": "text.strictdoc",
         "path": "./syntaxes/sdoc.tmLanguage.json"
       }
     ]

--- a/parse_syntax.js
+++ b/parse_syntax.js
@@ -11,7 +11,7 @@ const vscodeOnigurumaLib = oniguruma.loadWASM(wasmBin).then(() => {
     };
 });
 
-const scopeName = "source.sdoc";
+const scopeName = "text.strictdoc";
 const grammarPath = path.join(__dirname, "syntaxes/sdoc.tmLanguage.json");
 const filePath = process.argv[2];
 if (!fs.existsSync(filePath)) {

--- a/syntaxes/sdoc.tmLanguage.json
+++ b/syntaxes/sdoc.tmLanguage.json
@@ -744,5 +744,5 @@
             ]
         }
     },
-    "scopeName": "source.sdoc"
+    "scopeName": "text.strictdoc"
 }

--- a/tests/integration/syntax/01_basic_document_node/test.itest
+++ b/tests/integration/syntax/01_basic_document_node/test.itest
@@ -1,7 +1,7 @@
 RUN: %parse_syntax %S/sample.sdoc | filecheck %s --dump-input=fail
 
-CHECK: [1:0-10] "[DOCUMENT]" → source.sdoc keyword.sdoc
-CHECK: [2:0-5] "TITLE" → source.sdoc keyword.control.sdoc keyword.control.sdoc
-CHECK: [2:5-7] ": " → source.sdoc keyword.control.sdoc
-CHECK: [2:7-22] "Document Title" → source.sdoc keyword.control.sdoc string.sdoc
-CHECK: [3:0-1] "" → source.sdoc
+CHECK: [1:0-10] "[DOCUMENT]" → text.strictdoc keyword.sdoc
+CHECK: [2:0-5] "TITLE" → text.strictdoc keyword.control.sdoc keyword.control.sdoc
+CHECK: [2:5-7] ": " → text.strictdoc keyword.control.sdoc
+CHECK: [2:7-22] "Document Title" → text.strictdoc keyword.control.sdoc string.sdoc
+CHECK: [3:0-1] "" → text.strictdoc

--- a/tests/integration/syntax/composite/invalid/test.itest
+++ b/tests/integration/syntax/composite/invalid/test.itest
@@ -1,19 +1,19 @@
 RUN: %parse_syntax %S/sample.sdoc | filecheck %s --dump-input=fail
 
-CHECK: [1:0-10] "[DOCUMENT]" → source.sdoc keyword.sdoc
-CHECK: [2:0-5] "TITLE" → source.sdoc keyword.control.sdoc keyword.control.sdoc
-CHECK: [2:5-7] ": " → source.sdoc keyword.control.sdoc
-CHECK: [2:7-38] "Document with invalid examples" → source.sdoc keyword.control.sdoc string.sdoc
-CHECK: [3:0-1] "" → source.sdoc
-CHECK: [4:0-12] "[[DOCUMENT]]" → source.sdoc invalid.illegal.sdoc
-CHECK: [5:0-1] "" → source.sdoc
-CHECK: [6:0-13] "[[/DOCUMENT]]" → source.sdoc invalid.illegal.sdoc
-CHECK: [7:0-1] "" → source.sdoc
-CHECK: [8:0-11] "[[GRAMMAR]]" → source.sdoc invalid.illegal.sdoc
-CHECK: [9:0-1] "" → source.sdoc
-CHECK: [10:0-12] "[[/GRAMMAR]]" → source.sdoc invalid.illegal.sdoc
-CHECK: [11:0-1] "" → source.sdoc
-CHECK: [12:0-22] "[[DOCUMENT_FROM_FILE]]" → source.sdoc invalid.illegal.sdoc
-CHECK: [13:0-1] "" → source.sdoc
-CHECK: [14:0-23] "[[/DOCUMENT_FROM_FILE]]" → source.sdoc invalid.illegal.sdoc
-CHECK: [15:0-1] "" → source.sdoc
+CHECK: [1:0-10] "[DOCUMENT]" → text.strictdoc keyword.sdoc
+CHECK: [2:0-5] "TITLE" → text.strictdoc keyword.control.sdoc keyword.control.sdoc
+CHECK: [2:5-7] ": " → text.strictdoc keyword.control.sdoc
+CHECK: [2:7-38] "Document with invalid examples" → text.strictdoc keyword.control.sdoc string.sdoc
+CHECK: [3:0-1] "" → text.strictdoc
+CHECK: [4:0-12] "[[DOCUMENT]]" → text.strictdoc invalid.illegal.sdoc
+CHECK: [5:0-1] "" → text.strictdoc
+CHECK: [6:0-13] "[[/DOCUMENT]]" → text.strictdoc invalid.illegal.sdoc
+CHECK: [7:0-1] "" → text.strictdoc
+CHECK: [8:0-11] "[[GRAMMAR]]" → text.strictdoc invalid.illegal.sdoc
+CHECK: [9:0-1] "" → text.strictdoc
+CHECK: [10:0-12] "[[/GRAMMAR]]" → text.strictdoc invalid.illegal.sdoc
+CHECK: [11:0-1] "" → text.strictdoc
+CHECK: [12:0-22] "[[DOCUMENT_FROM_FILE]]" → text.strictdoc invalid.illegal.sdoc
+CHECK: [13:0-1] "" → text.strictdoc
+CHECK: [14:0-23] "[[/DOCUMENT_FROM_FILE]]" → text.strictdoc invalid.illegal.sdoc
+CHECK: [15:0-1] "" → text.strictdoc

--- a/tests/integration/syntax/composite/section/test.itest
+++ b/tests/integration/syntax/composite/section/test.itest
@@ -1,14 +1,14 @@
 RUN: %parse_syntax %S/sample.sdoc | filecheck %s --dump-input=fail
 
-CHECK: [1:0-10] "[DOCUMENT]" → source.sdoc keyword.sdoc
-CHECK: [2:0-5] "TITLE" → source.sdoc keyword.control.sdoc keyword.control.sdoc
-CHECK: [2:5-7] ": " → source.sdoc keyword.control.sdoc
-CHECK: [2:7-39] "Document with composite SECTION" → source.sdoc keyword.control.sdoc string.sdoc
-CHECK: [3:0-1] "" → source.sdoc
-CHECK: [4:0-11] "[[SECTION]]" → source.sdoc keyword.sdoc
-CHECK: [5:0-5] "TITLE" → source.sdoc keyword.control.sdoc keyword.control.sdoc
-CHECK: [5:5-7] ": " → source.sdoc keyword.control.sdoc
-CHECK: [5:7-21] "Valid section" → source.sdoc keyword.control.sdoc string.sdoc
-CHECK: [6:0-1] "" → source.sdoc
-CHECK: [7:0-12] "[[/SECTION]]" → source.sdoc keyword.sdoc
-CHECK: [8:0-1] "" → source.sdoc
+CHECK: [1:0-10] "[DOCUMENT]" → text.strictdoc keyword.sdoc
+CHECK: [2:0-5] "TITLE" → text.strictdoc keyword.control.sdoc keyword.control.sdoc
+CHECK: [2:5-7] ": " → text.strictdoc keyword.control.sdoc
+CHECK: [2:7-39] "Document with composite SECTION" → text.strictdoc keyword.control.sdoc string.sdoc
+CHECK: [3:0-1] "" → text.strictdoc
+CHECK: [4:0-11] "[[SECTION]]" → text.strictdoc keyword.sdoc
+CHECK: [5:0-5] "TITLE" → text.strictdoc keyword.control.sdoc keyword.control.sdoc
+CHECK: [5:5-7] ": " → text.strictdoc keyword.control.sdoc
+CHECK: [5:7-21] "Valid section" → text.strictdoc keyword.control.sdoc string.sdoc
+CHECK: [6:0-1] "" → text.strictdoc
+CHECK: [7:0-12] "[[/SECTION]]" → text.strictdoc keyword.sdoc
+CHECK: [8:0-1] "" → text.strictdoc

--- a/tests/integration/syntax/composite/valid/test.itest
+++ b/tests/integration/syntax/composite/valid/test.itest
@@ -1,21 +1,21 @@
 RUN: %parse_syntax %S/sample.sdoc | filecheck %s --dump-input=fail
 
-CHECK: [1:0-10] "[DOCUMENT]" → source.sdoc keyword.sdoc
-CHECK: [2:0-5] "TITLE" → source.sdoc keyword.control.sdoc keyword.control.sdoc
-CHECK: [2:5-7] ": " → source.sdoc keyword.control.sdoc
-CHECK: [2:7-46] "Document with valid composite examples" → source.sdoc keyword.control.sdoc string.sdoc
-CHECK: [3:0-1] "" → source.sdoc
-CHECK: [4:0-11] "[[SECTION]]" → source.sdoc keyword.sdoc
-CHECK: [5:0-5] "TITLE" → source.sdoc keyword.control.sdoc keyword.control.sdoc
-CHECK: [5:5-7] ": " → source.sdoc keyword.control.sdoc
-CHECK: [5:7-21] "Valid section" → source.sdoc keyword.control.sdoc string.sdoc
-CHECK: [6:0-1] "" → source.sdoc
-CHECK: [7:0-12] "[[/SECTION]]" → source.sdoc keyword.sdoc
-CHECK: [8:0-1] "" → source.sdoc
-CHECK: [9:0-12] "[[ANY_NAME]]" → source.sdoc keyword.sdoc
-CHECK: [10:0-5] "TITLE" → source.sdoc keyword.control.sdoc keyword.control.sdoc
-CHECK: [10:5-7] ": " → source.sdoc keyword.control.sdoc
-CHECK: [10:7-22] "Composite node" → source.sdoc keyword.control.sdoc string.sdoc
-CHECK: [11:0-1] "" → source.sdoc
-CHECK: [12:0-13] "[[/ANY_NAME]]" → source.sdoc keyword.sdoc
-CHECK: [13:0-1] "" → source.sdoc
+CHECK: [1:0-10] "[DOCUMENT]" → text.strictdoc keyword.sdoc
+CHECK: [2:0-5] "TITLE" → text.strictdoc keyword.control.sdoc keyword.control.sdoc
+CHECK: [2:5-7] ": " → text.strictdoc keyword.control.sdoc
+CHECK: [2:7-46] "Document with valid composite examples" → text.strictdoc keyword.control.sdoc string.sdoc
+CHECK: [3:0-1] "" → text.strictdoc
+CHECK: [4:0-11] "[[SECTION]]" → text.strictdoc keyword.sdoc
+CHECK: [5:0-5] "TITLE" → text.strictdoc keyword.control.sdoc keyword.control.sdoc
+CHECK: [5:5-7] ": " → text.strictdoc keyword.control.sdoc
+CHECK: [5:7-21] "Valid section" → text.strictdoc keyword.control.sdoc string.sdoc
+CHECK: [6:0-1] "" → text.strictdoc
+CHECK: [7:0-12] "[[/SECTION]]" → text.strictdoc keyword.sdoc
+CHECK: [8:0-1] "" → text.strictdoc
+CHECK: [9:0-12] "[[ANY_NAME]]" → text.strictdoc keyword.sdoc
+CHECK: [10:0-5] "TITLE" → text.strictdoc keyword.control.sdoc keyword.control.sdoc
+CHECK: [10:5-7] ": " → text.strictdoc keyword.control.sdoc
+CHECK: [10:7-22] "Composite node" → text.strictdoc keyword.control.sdoc string.sdoc
+CHECK: [11:0-1] "" → text.strictdoc
+CHECK: [12:0-13] "[[/ANY_NAME]]" → text.strictdoc keyword.sdoc
+CHECK: [13:0-1] "" → text.strictdoc

--- a/tests/integration/syntax/deprecated/closing_non_composite_tag/test.itest
+++ b/tests/integration/syntax/deprecated/closing_non_composite_tag/test.itest
@@ -1,5 +1,5 @@
 RUN: %parse_syntax %S/sample.sdoc | filecheck %s --dump-input=fail
 
-CHECK: [4:0-23] "[COMPOSITE_REQUIREMENT]" → source.sdoc keyword.sdoc
-CHECK: [5:11-74] "This tag name is possible, but will not create a composite node" → source.sdoc string.unquoted
-CHECK: [7:0-24] "[/COMPOSITE_REQUIREMENT]" → source.sdoc invalid.illegal.sdoc
+CHECK: [4:0-23] "[COMPOSITE_REQUIREMENT]" → text.strictdoc keyword.sdoc
+CHECK: [5:11-74] "This tag name is possible, but will not create a composite node" → text.strictdoc string.unquoted
+CHECK: [7:0-24] "[/COMPOSITE_REQUIREMENT]" → text.strictdoc invalid.illegal.sdoc

--- a/tests/integration/syntax/deprecated/document_options/test.itest
+++ b/tests/integration/syntax/deprecated/document_options/test.itest
@@ -1,6 +1,6 @@
 RUN: %parse_syntax %S/sample.sdoc | filecheck %s --dump-input=fail
 
-CHECK: [3:0-10] "REQ_PREFIX" → source.sdoc keyword.control.sdoc invalid.deprecated.sdoc
-CHECK: [4:0-8] "OPTIONS:" → source.sdoc keyword.control.sdoc
-CHECK: [5:0-20] "  REQUIREMENT_STYLE:" → source.sdoc invalid.deprecated.sdoc
-CHECK: [6:0-21] "  REQUIREMENT_IN_TOC:" → source.sdoc invalid.deprecated.sdoc
+CHECK: [3:0-10] "REQ_PREFIX" → text.strictdoc keyword.control.sdoc invalid.deprecated.sdoc
+CHECK: [4:0-8] "OPTIONS:" → text.strictdoc keyword.control.sdoc
+CHECK: [5:0-20] "  REQUIREMENT_STYLE:" → text.strictdoc invalid.deprecated.sdoc
+CHECK: [6:0-21] "  REQUIREMENT_IN_TOC:" → text.strictdoc invalid.deprecated.sdoc

--- a/tests/integration/syntax/deprecated/grammar_type_reference_choice/test.itest
+++ b/tests/integration/syntax/deprecated/grammar_type_reference_choice/test.itest
@@ -1,5 +1,5 @@
 RUN: %parse_syntax %S/sample.sdoc | filecheck %s --dump-input=fail
 
-CHECK: [9:10-28] "ParentReqReference" → source.sdoc invalid.deprecated
-CHECK: [11:10-23] "FileReference" → source.sdoc invalid.deprecated
-CHECK: [13:10-22] "BibReference" → source.sdoc invalid.deprecated
+CHECK: [9:10-28] "ParentReqReference" → text.strictdoc invalid.deprecated
+CHECK: [11:10-23] "FileReference" → text.strictdoc invalid.deprecated
+CHECK: [13:10-22] "BibReference" → text.strictdoc invalid.deprecated

--- a/tests/integration/syntax/deprecated/refs/test.itest
+++ b/tests/integration/syntax/deprecated/refs/test.itest
@@ -1,3 +1,3 @@
 RUN: %parse_syntax %S/sample.sdoc | filecheck %s --dump-input=fail
 
-CHECK: [6:0-6] "REFS:" → source.sdoc invalid.deprecated.sdoc
+CHECK: [6:0-6] "REFS:" → text.strictdoc invalid.deprecated.sdoc

--- a/tests/integration/syntax/deprecated/section/test.itest
+++ b/tests/integration/syntax/deprecated/section/test.itest
@@ -1,4 +1,4 @@
 RUN: %parse_syntax %S/sample.sdoc | filecheck %s --dump-input=fail
 
-CHECK: [4:0-9] "[SECTION]" → source.sdoc invalid.deprecated.sdoc
-CHECK: [7:0-10] "[/SECTION]" → source.sdoc invalid.deprecated.sdoc
+CHECK: [4:0-9] "[SECTION]" → text.strictdoc invalid.deprecated.sdoc
+CHECK: [7:0-10] "[/SECTION]" → text.strictdoc invalid.deprecated.sdoc


### PR DESCRIPTION


From learning more about GitHub's linguist repo, it is clear that StrictDoc markup should be better registered under "text.*" namespace.

RATIONALE: SDoc is really a text markup like RST, not a programming language like Python.