### PR TITLE
feat(sdoc.tmLanguage.json): change content type: "source.rst" -> "text.restructuredtext"

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ git clone git@github.com:strictdoc-project/strictdoc.tmLanguage.git
 
 In the cloned `strictdoc.tmLanguage` folder, there is a file called
 `syntaxes/sdoc.tmLanguage.json`. Open that file and replace all occurrences of
-`source.rst` with `lngpck.source.rst`. This is needed because TM4E language
+`text.restructuredtext` with `lngpck.text.restructuredtext`. This is needed because TM4E language
 repository maintains all its .json language files under the `lngpck.*`
-namespace. Changing to `lngpck.source.rst` helps the StrictDoc grammar to
+namespace. Changing to `lngpck.text.restructuredtext` helps the StrictDoc grammar to
 properly locate the RST grammar in Eclipse.
 
 Follow the same steps as for RST above: import the `sdoc.tmLanguage.json` file.

--- a/syntaxes/sdoc.tmLanguage.json
+++ b/syntaxes/sdoc.tmLanguage.json
@@ -718,11 +718,11 @@
         "value_rst": {
             "begin": ">>>$",
             "end": "^<<<$",
-            "contentName": "source.rst",
+            "contentName": "text.restructuredtext",
             "patterns": [
                 {
                     "comment": "FIXME: # 'The problem of leaking incorrect RST markup'. An invalid included RST markup breaks further markup of the file by exceeding the scope and eating at least one end-of-scope marker. In the file tmLanguage (plist) in the program TextMate it was possible to capture the scope with RST content more clearly, and the RST text does not leak to the limits of the scope. Using this method in this file does not work.",
-                    "include": "source.rst"
+                    "include": "text.restructuredtext"
                 }
             ],
             "captures": { "0": { "name": "string.quoted.double.sdoc" } }


### PR DESCRIPTION


From learning more about GitHub's linguist repo, it is clear that the RST markup should be better registered under "text.*" namespace.